### PR TITLE
cross product

### DIFF
--- a/VectorArithmetic/VectorArithmetic.swift
+++ b/VectorArithmetic/VectorArithmetic.swift
@@ -136,6 +136,10 @@ struct InternalVectorArithmetic {
   static func dotProduct <T : VectorOperatable, U : VectorOperatable > (vector:T, otherVector:U) -> Double  {
     return (vector.horizontal*otherVector.horizontal) + (vector.vertical*otherVector.vertical)
   }
+  static func crossProduct <T : VectorOperatable, U : VectorOperatable > (vector:T, otherVector:U) -> Double  {
+    let deltaAngle = sin(angleInRadians(vector) - angleInRadians(otherVector))
+    return magnitude(vector) * magnitude(otherVector) * deltaAngle
+  }
   
   
   static func distanceTo <T : VectorArithmetic, U : VectorArithmetic > (vector:T, otherVector:U) -> Double {


### PR DESCRIPTION
Cross product is implemented as per our conversation on twitter. I believe this fits in with the Swift magic I don't get -- I used `dotProduct` as an example. I tested it against Python and looked at your `angleInRadians` and `magnitude` to ensure they returned the correct values.

Depending on how you init your vectors, the [right hand rule](https://en.wikipedia.org/wiki/Right_hand_rule) may take effect and switch the sign. If the sign is flipped from NumPy (below), switch either the (x, y) components or the `angle(x) - angle(y)` around.

There are [other ways](https://en.wikipedia.org/wiki/Cross_product#Alternative_formulation) to compute the cross product. While [defined for only three dimensions](http://math.stackexchange.com/questions/185991/is-the-vector-cross-product-only-defined-for-3d), it can be defined for n dimensions using exterior algebra and the [Hodge star operator](http://en.wikipedia.org/wiki/Hodge_dual).

``` python
In [2]: from pylab import array, cross

In [3]: x = array([1, 0])

In [4]: y = array([sqrt(3), sqrt(2)])/2

In [5]: cross(x, y)
Out[5]: 0.70710678118654757
```
