### PR TITLE
Support Double * VectorOperatable

### DIFF
--- a/TestsAndSample/TestsAndSampleTests/TestsGenericOperators.swift
+++ b/TestsAndSample/TestsAndSampleTests/TestsGenericOperators.swift
@@ -178,6 +178,10 @@ class TestsGenericOperators<T:VectorOperatable, U:VectorOperatable, Z:VectorOper
     XCTAssertEqual(self.vectorVector.horizontal, pow(self.doubleValue, 2))
     XCTAssertEqual(self.vectorVector.vertical, pow(self.doubleValue, 2))
     
+    self.vectorVector = 2 * self.vectorVector
+    XCTAssertEqual(self.vectorVector.horizontal, pow(self.doubleValue, 3))
+    XCTAssertEqual(self.vectorVector.vertical, pow(self.doubleValue, 3))
+    
   }
   func testMultiplicationScalarAssignment() {
     self.vectorVector *= 2

--- a/VectorArithmetic/VectorArithmetic.swift
+++ b/VectorArithmetic/VectorArithmetic.swift
@@ -106,6 +106,9 @@ func /= <T:VectorOperatable>(inout lhs:T, scalar:Double) -> T  {
 func * <T:VectorOperatable>(lhs: T, scalar:Double) -> T  {
   return T(horizontal: lhs.horizontal*scalar, vertical: lhs.vertical*scalar)
 }
+func * <T:VectorOperatable>(scalar:Double, rhs: T) -> T  {
+  return T(horizontal: rhs.horizontal*scalar, vertical: rhs.vertical*scalar)
+}
 func *= <T:VectorOperatable>(inout lhs: T, value:Double)   {
   lhs = lhs * value
 }


### PR DESCRIPTION
Conventionally in mathematics a scalar coefficient is put in front of a symbol like a vector, e.g. `5 * v` as opposed to `v * 5`. So we should support both.
